### PR TITLE
Restore standard AGPL license text

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -35,7 +35,7 @@ receive widespread use, become available for other developers to
 incorporate.  Many developers of free software are heartened and
 encouraged by the resulting cooperation.  However, in the case of
 software used on network servers, this result may fail to come about.
-The GNU Affero General Public License permits making a modified version and
+The GNU General Public License permits making a modified version and
 letting the public access it on a server without ever releasing its
 source code to the public.
 
@@ -537,7 +537,7 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Remote Network Interaction; Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
 
   Notwithstanding any other provision of this License, if you modify the
 Program, your modified version must prominently offer all users
@@ -547,16 +547,16 @@ Source of your version by providing access to the Corresponding Source
 from a network server at no charge, through some standard or customary
 means of facilitating copying of software.  This Corresponding Source
 shall include the Corresponding Source for any work covered by version 3
-of the GNU Affero General Public License that is incorporated pursuant to the
+of the GNU General Public License that is incorporated pursuant to the
 following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
 but the work with which it is combined will remain governed by version
-3 of the GNU Affero General Public License.
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 


### PR DESCRIPTION
Commit 21cff0545cebb1a8951089ca9805dbfc7c5f2621 mistakenly made replacements in license text.
This restores the standard text from https://www.gnu.org/licenses/agpl-3.0.txt

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>